### PR TITLE
45 endpoint patch location riddlesratescore=

### DIFF
--- a/findme-location-riddles/handler.py
+++ b/findme-location-riddles/handler.py
@@ -73,7 +73,7 @@ def get_location_riddles_by_location_riddle_id(location_riddle_id: Annotated[int
 def rate_location_riddle(location_riddle_id: Annotated[int, Path(lt=999)]):
     user_id = __get_id(app)
     return location_riddles_service.rate_location_riddle(location_riddle_id, user_id,
-                                                         int(app.current_event.json_body['rating']))
+                                                         app.current_event.json_body['rating'])
 
 
 @app.delete("/location-riddles/<location_riddle_id>")

--- a/findme-location-riddles/handler.py
+++ b/findme-location-riddles/handler.py
@@ -67,6 +67,15 @@ def get_location_riddles_by_location_riddle_id(location_riddle_id: Annotated[int
     return location_riddles_service.get_location_riddle(location_riddle_id)
 
 
+@app.patch("/location-riddles/<location_riddle_id>/rate")
+@tracer.capture_method
+@authorizer.requires_auth(app=app)
+def rate_location_riddle(location_riddle_id: Annotated[int, Path(lt=999)]):
+    user_id = __get_id(app)
+    score = app.current_event.query_string_parameters.get("score")
+    return {"user_id": user_id, "score": score, "location_riddle_id": location_riddle_id}
+
+
 @app.delete("/location-riddles/<location_riddle_id>")
 @tracer.capture_method
 @authorizer.requires_auth(app=app)

--- a/findme-location-riddles/handler.py
+++ b/findme-location-riddles/handler.py
@@ -72,8 +72,8 @@ def get_location_riddles_by_location_riddle_id(location_riddle_id: Annotated[int
 @authorizer.requires_auth(app=app)
 def rate_location_riddle(location_riddle_id: Annotated[int, Path(lt=999)]):
     user_id = __get_id(app)
-    score = app.current_event.query_string_parameters.get("score")
-    return location_riddles_service.rate_location_riddle(location_riddle_id, user_id, score)
+    rating = app.current_event.query_string_parameters.get("rating")
+    return location_riddles_service.rate_location_riddle(location_riddle_id, user_id, int(rating))
 
 
 @app.delete("/location-riddles/<location_riddle_id>")

--- a/findme-location-riddles/handler.py
+++ b/findme-location-riddles/handler.py
@@ -73,7 +73,7 @@ def get_location_riddles_by_location_riddle_id(location_riddle_id: Annotated[int
 def rate_location_riddle(location_riddle_id: Annotated[int, Path(lt=999)]):
     user_id = __get_id(app)
     score = app.current_event.query_string_parameters.get("score")
-    return {"user_id": user_id, "score": score, "location_riddle_id": location_riddle_id}
+    return location_riddles_service.rate_location_riddle(location_riddle_id, user_id, score)
 
 
 @app.delete("/location-riddles/<location_riddle_id>")

--- a/findme-location-riddles/handler.py
+++ b/findme-location-riddles/handler.py
@@ -72,8 +72,8 @@ def get_location_riddles_by_location_riddle_id(location_riddle_id: Annotated[int
 @authorizer.requires_auth(app=app)
 def rate_location_riddle(location_riddle_id: Annotated[int, Path(lt=999)]):
     user_id = __get_id(app)
-    rating = app.current_event.query_string_parameters.get("rating")
-    return location_riddles_service.rate_location_riddle(location_riddle_id, user_id, int(rating))
+    return location_riddles_service.rate_location_riddle(location_riddle_id, user_id,
+                                                         int(app.current_event.json_body['rating']))
 
 
 @app.delete("/location-riddles/<location_riddle_id>")

--- a/findme-location-riddles/src/LocationRiddle.py
+++ b/findme-location-riddles/src/LocationRiddle.py
@@ -1,12 +1,24 @@
 from datetime import datetime
 
 from pydantic import BaseModel
+from typing import List
+
+
+class Rating(BaseModel):
+    user_id: str
+    rating: int
 
 
 class LocationRiddle(BaseModel):
     location_riddle_id: str
     user_id: str
-    ratings: list = []
+    ratings: List[Rating] = []
     comments: list = []
     guesses: list = []
     created_at: int = int(datetime.now().timestamp())
+    average_rating: float = None
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        if self.ratings and isinstance(self.ratings[0], Rating):
+            self.average_rating = sum(rating.rating for rating in self.ratings) / len(self.ratings)

--- a/findme-location-riddles/src/LocationRiddle.py
+++ b/findme-location-riddles/src/LocationRiddle.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from pydantic import BaseModel
-from typing import List
+from typing import List, Optional
 
 
 class Rating(BaseModel):
@@ -16,7 +16,7 @@ class LocationRiddle(BaseModel):
     comments: list = []
     guesses: list = []
     created_at: int = int(datetime.now().timestamp())
-    average_rating: float = None
+    average_rating: Optional[float] = None
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/findme-location-riddles/src/LocationRiddlesRepository.py
+++ b/findme-location-riddles/src/LocationRiddlesRepository.py
@@ -69,17 +69,16 @@ class LocationRiddlesRepository(AbstractLocationRiddlesRepository):
 
         return location_riddle
 
-    def update_location_riddle_rating_in_db(self, location_riddle_id, user_id, score):
+    def update_location_riddle_rating_in_db(self, location_riddle_id, user_id, rating):
         try:
             self.table.update_item(
                 Key={"location_riddle_id": location_riddle_id},
                 UpdateExpression="SET ratings = list_append(ratings, :i)",
-                ExpressionAttributeValues={":i": [{"user_id": user_id, "score": score}]},
+                ExpressionAttributeValues={":i": [{"user_id": user_id, "rating": rating}]},
             )
         except ClientError as e:
             print(f"Error updating location_riddle rating in DynamoDB: {e}")
             raise BadRequestError(f"Error updating location_riddle rating in DynamoDB: {e}")
-
         return self.get_location_riddle_by_location_riddle_id_from_db(location_riddle_id)
 
     def delete_location_riddle_from_db(self, location_riddle_id):

--- a/findme-location-riddles/src/LocationRiddlesRepository.py
+++ b/findme-location-riddles/src/LocationRiddlesRepository.py
@@ -69,6 +69,19 @@ class LocationRiddlesRepository(AbstractLocationRiddlesRepository):
 
         return location_riddle
 
+    def update_location_riddle_rating_in_db(self, location_riddle_id, user_id, score):
+        try:
+            self.table.update_item(
+                Key={"location_riddle_id": location_riddle_id},
+                UpdateExpression="SET ratings = list_append(ratings, :i)",
+                ExpressionAttributeValues={":i": [{"user_id": user_id, "score": score}]},
+            )
+        except ClientError as e:
+            print(f"Error updating location_riddle rating in DynamoDB: {e}")
+            raise BadRequestError(f"Error updating location_riddle rating in DynamoDB: {e}")
+
+        return self.get_location_riddle_by_location_riddle_id_from_db(location_riddle_id)
+
     def delete_location_riddle_from_db(self, location_riddle_id):
         try:
             self.table.delete_item(Key={"location_riddle_id": location_riddle_id})

--- a/findme-location-riddles/src/LocationRiddlesService.py
+++ b/findme-location-riddles/src/LocationRiddlesService.py
@@ -53,10 +53,10 @@ class LocationRiddlesService:
             key = f"location-riddles/{location_riddle.location_riddle_id}.png"
             location_riddle_image = self.image_bucket_repository.get_image_from_s3(key)
             response.append(
-                location_riddle.dict()
+                location_riddle.dict(exclude={"ratings"})
                 | {"location_riddle_image": location_riddle_image}
             )
-        return response.dict(exclude={"ratings"})
+        return response
 
     def get_location_riddles_feed(self, event, user):
         following_users = self.__get_following_users_list(event, user)
@@ -70,7 +70,7 @@ class LocationRiddlesService:
         return response
 
     def rate_location_riddle(self, location_riddle_id, user_id, rating):
-        if not isinstance(rating, int) and not 1 <= rating <= 5:
+        if not (isinstance(rating, int) and 1 <= rating <= 5):
             raise BadRequestError("Rating must be a number between 1 and 5")
 
         location_riddle = self.location_riddle_repository.get_location_riddle_by_location_riddle_id_from_db(
@@ -79,8 +79,8 @@ class LocationRiddlesService:
 
         if location_riddle.user_id == user_id:
             raise BadRequestError("User cannot rate their own location riddle")
-        for rating in location_riddle.ratings:
-            if rating.user_id == user_id:
+        for rating_entry in location_riddle.ratings:
+            if rating_entry.user_id == user_id:
                 raise BadRequestError("User has already rated this location riddle")
         # TODO: check if requesting user is following the user_id
 

--- a/findme-location-riddles/src/LocationRiddlesService.py
+++ b/findme-location-riddles/src/LocationRiddlesService.py
@@ -69,6 +69,27 @@ class LocationRiddlesService:
                 continue
         return response
 
+    def rate_location_riddle(self, location_riddle_id, user_id, score):
+        location_riddle = self.location_riddle_repository.get_location_riddle_by_location_riddle_id_from_db(
+            location_riddle_id
+        )
+
+        if location_riddle.user_id == user_id:
+            raise BadRequestError("User cannot rate their own location riddle")
+        for rating in location_riddle.ratings:
+            if rating.user_id == user_id:
+                raise BadRequestError("User has already rated this location riddle")
+        # TODO: check if requesting user is following the user_id
+
+        try:
+            response = self.location_riddle_repository.update_location_riddle_rating_in_db(
+                location_riddle_id, user_id, score
+            )
+        except Exception as e:
+            raise BadRequestError(e)
+
+        return response
+
     def delete_location_riddle(self, location_riddle_id, user_id):
         location_riddle = self.location_riddle_repository.get_location_riddle_by_location_riddle_id_from_db(
             location_riddle_id

--- a/findme-location-riddles/src/LocationRiddlesService.py
+++ b/findme-location-riddles/src/LocationRiddlesService.py
@@ -69,7 +69,10 @@ class LocationRiddlesService:
                 continue
         return response
 
-    def rate_location_riddle(self, location_riddle_id, user_id, score):
+    def rate_location_riddle(self, location_riddle_id, user_id, rating):
+        if not isinstance(rating, int) and not 1 <= rating <= 5:
+            raise BadRequestError("Rating must be a number between 1 and 5")
+
         location_riddle = self.location_riddle_repository.get_location_riddle_by_location_riddle_id_from_db(
             location_riddle_id
         )
@@ -83,7 +86,7 @@ class LocationRiddlesService:
 
         try:
             response = self.location_riddle_repository.update_location_riddle_rating_in_db(
-                location_riddle_id, user_id, score
+                location_riddle_id, user_id, rating
             )
         except Exception as e:
             raise BadRequestError(e)

--- a/findme-location-riddles/src/LocationRiddlesService.py
+++ b/findme-location-riddles/src/LocationRiddlesService.py
@@ -36,7 +36,7 @@ class LocationRiddlesService:
         key = f"location-riddles/{location_riddle.location_riddle_id}.png"
         location_riddle_image = self.image_bucket_repository.get_image_from_s3(key)
 
-        return location_riddle.dict() | {"location_riddle_image": location_riddle_image}
+        return location_riddle.dict(exclude={"ratings"}) | {"location_riddle_image": location_riddle_image}
 
     def get_location_riddles_for_user(self, user_id):
         # TODO: check if requesting user is following the user_id
@@ -56,7 +56,7 @@ class LocationRiddlesService:
                 location_riddle.dict()
                 | {"location_riddle_image": location_riddle_image}
             )
-        return response
+        return response.dict(exclude={"ratings"})
 
     def get_location_riddles_feed(self, event, user):
         following_users = self.__get_following_users_list(event, user)
@@ -91,7 +91,7 @@ class LocationRiddlesService:
         except Exception as e:
             raise BadRequestError(e)
 
-        return response
+        return response.dict(exclude={"ratings"})
 
     def delete_location_riddle(self, location_riddle_id, user_id):
         location_riddle = self.location_riddle_repository.get_location_riddle_by_location_riddle_id_from_db(

--- a/findme-location-riddles/src/base/AbstractLocationRiddlesRepository.py
+++ b/findme-location-riddles/src/base/AbstractLocationRiddlesRepository.py
@@ -16,5 +16,9 @@ class AbstractLocationRiddlesRepository(ABC):
         pass
 
     @abstractmethod
+    def update_location_riddle_rating_in_db(self, location_riddle_id, user_id, rating):
+        pass
+
+    @abstractmethod
     def delete_location_riddle_from_db(self, location_riddle_id):
         pass

--- a/findme-location-riddles/src/test/MockLocationRiddlesRepository.py
+++ b/findme-location-riddles/src/test/MockLocationRiddlesRepository.py
@@ -28,6 +28,12 @@ class LocationRiddle:
             attr: value for attr, value in self.__dict__.items() if attr not in exclude
         }
 
+    def update_avg_rating(self):
+        if len(self.ratings) == 0:
+            self.average_rating = None
+            return
+        self.average_rating = sum([rating.rating for rating in self.ratings]) / len(self.ratings)
+
 
 class MockLocationRiddlesRepository(AbstractLocationRiddlesRepository):
     def __init__(self):
@@ -40,6 +46,11 @@ class MockLocationRiddlesRepository(AbstractLocationRiddlesRepository):
         return [self.mock_data]
 
     def get_location_riddle_by_location_riddle_id_from_db(self, location_riddle_id):
+        return self.mock_data
+
+    def update_location_riddle_rating_in_db(self, location_riddle_id, user_id, rating):
+        self.mock_data.ratings.append(Rating(user_id, rating))
+        self.mock_data.update_avg_rating()
         return self.mock_data
 
     def delete_location_riddle_from_db(self, location_riddle_id):

--- a/findme-location-riddles/src/test/MockLocationRiddlesRepository.py
+++ b/findme-location-riddles/src/test/MockLocationRiddlesRepository.py
@@ -1,8 +1,19 @@
 from src.base.AbstractLocationRiddlesRepository import AbstractLocationRiddlesRepository
 
 
-class LocationRiddle:
+class Rating:
+    def __init__(self, user_id: str, rating: int):
+        self.user_id = user_id
+        self.rating = rating
 
+    def dict(self):
+        return {
+            "user_id": self.user_id,
+            "rating": self.rating
+        }
+
+
+class LocationRiddle:
     def __init__(self):
         self.location_riddle_id = "mock_location_riddle_id"
         self.user_id = "mock_user_id"
@@ -10,15 +21,11 @@ class LocationRiddle:
         self.comments = []
         self.guesses = []
         self.created_at = 1234567890
+        self.average_rating = None
 
-    def dict(self):
+    def dict(self, exclude=set()):
         return {
-            "location_riddle_id": self.location_riddle_id,
-            "user_id": self.user_id,
-            "ratings": self.ratings,
-            "comments": self.comments,
-            "guesses": self.guesses,
-            "created_at": self.created_at
+            attr: value for attr, value in self.__dict__.items() if attr not in exclude
         }
 
 

--- a/findme-location-riddles/tests/test_location_riddle_service.py
+++ b/findme-location-riddles/tests/test_location_riddle_service.py
@@ -18,8 +18,8 @@ class TestLocationRiddleService(unittest.TestCase):
         self.assertEqual(self.location_riddles_service.get_location_riddle("mock_location_riddle_id"),
                          {
                              "location_riddle_id": "mock_location_riddle_id",
-                             "user_id": "mock_user_id", "ratings": [], "comments": [],
-                             "guesses": [], "created_at": 1234567890,
+                             "user_id": "mock_user_id", "comments": [],
+                             "guesses": [], "created_at": 1234567890, "average_rating": None,
                              "location_riddle_image": {"image_base64": "mock_image_base64",
                                                        "Content-Type": "image/png"}
                          })
@@ -28,8 +28,8 @@ class TestLocationRiddleService(unittest.TestCase):
         self.assertEqual(self.location_riddles_service.get_location_riddles_for_user("mock_user_id"),
                          [{
                              "location_riddle_id": "mock_location_riddle_id",
-                             "user_id": "mock_user_id", "ratings": [], "comments": [],
-                             "guesses": [], "created_at": 1234567890,
+                             "user_id": "mock_user_id", "comments": [],
+                             "guesses": [], "created_at": 1234567890, "average_rating": None,
                              "location_riddle_image": {"image_base64": "mock_image_base64",
                                                        "Content-Type": "image/png"}
                          }])

--- a/findme-location-riddles/tests/test_location_riddle_service.py
+++ b/findme-location-riddles/tests/test_location_riddle_service.py
@@ -34,6 +34,34 @@ class TestLocationRiddleService(unittest.TestCase):
                                                        "Content-Type": "image/png"}
                          }])
 
+    def test_rate_location_riddle(self):
+        # Test that the user can not rate its own location riddle
+        with self.assertRaises(Exception):
+            self.location_riddles_service.rate_location_riddle("mock_location_riddle_id",
+                                                              "mock_user_id", 6)
+
+        self.assertEqual(self.location_riddles_service.rate_location_riddle("mock_location_riddle_id",
+                                                                            "mock_user2_id", 3),
+                         {
+                             "location_riddle_id": "mock_location_riddle_id",
+                             "user_id": "mock_user_id", "comments": [],
+                             "guesses": [], "created_at": 1234567890, "average_rating": 3
+                         })
+
+        # Test that the user can not rate a location riddle twice
+        with self.assertRaises(Exception):
+            self.location_riddles_service.rate_location_riddle("mock_location_riddle_id",
+                                                              "mock_user2_id", 6)
+
+        self.assertEqual(self.location_riddles_service.rate_location_riddle("mock_location_riddle_id",
+                                                                            "mock_user3_id", 2),
+                         {
+                             "location_riddle_id": "mock_location_riddle_id",
+                             "user_id": "mock_user_id", "comments": [],
+                             "guesses": [], "created_at": 1234567890, "average_rating": 2.5
+                         })
+
+
     def test_delete_location_riddle(self):
         self.assertEqual(self.location_riddles_service.delete_location_riddle("mock_location_riddle_id", "mock_user_id"),
                          {"message": "Location riddle deleted successfully"})

--- a/serverless.yml
+++ b/serverless.yml
@@ -158,21 +158,45 @@ functions:
           method: get
           cors:
             origin: ${self:custom.stage.${opt:stage}.frontendOrigin}
+          request:
+            parameters:
+              paths:
+                id: true
       - http:
           path: /location-riddles/user/{user_id}
           method: get
           cors:
             origin: ${self:custom.stage.${opt:stage}.frontendOrigin}
+          request:
+            parameters:
+              paths:
+                id: true
       - http:
           path: /location-riddles/user
           method: get
           cors:
             origin: ${self:custom.stage.${opt:stage}.frontendOrigin}
       - http:
+          path: /location-riddles/{location_riddle_id}/rate
+          method: patch
+          cors:
+            origin: ${self:custom.stage.${opt:stage}.frontendOrigin}
+          request:
+            parameters:
+              paths:
+                id: true
+              querystrings:
+                score: true
+                type: false
+      - http:
           path: /location-riddles/{location_riddle_id}
           method: delete
           cors:
             origin: ${self:custom.stage.${opt:stage}.frontendOrigin}
+          request:
+            parameters:
+              paths:
+                id: true
 
 resources:
   extensions: ${file(./sls-config-${opt:stage}.yml), null}

--- a/serverless.yml
+++ b/serverless.yml
@@ -186,7 +186,7 @@ functions:
               paths:
                 id: true
               querystrings:
-                score: true
+                rating: true
                 type: false
       - http:
           path: /location-riddles/{location_riddle_id}

--- a/serverless.yml
+++ b/serverless.yml
@@ -181,13 +181,6 @@ functions:
           method: patch
           cors:
             origin: ${self:custom.stage.${opt:stage}.frontendOrigin}
-          request:
-            parameters:
-              paths:
-                id: true
-              querystrings:
-                rating: true
-                type: false
       - http:
           path: /location-riddles/{location_riddle_id}
           method: delete


### PR DESCRIPTION
we are currently not checking if the current user is following the user who posted the riddle. I think we should resolve all the following todos together in a separate PR.

The endpoint checks that a user can not rate a riddle twice and saves the ratings like this:
<img width="508" alt="image" src="https://github.com/uzh-ase-fs24/backend/assets/91185670/eee52b31-d334-484c-a96c-8b91e44bae46">
@frontendgods what do you think about that?